### PR TITLE
Bucket name fix

### DIFF
--- a/src/punctuate/punctuate_text.py
+++ b/src/punctuate/punctuate_text.py
@@ -50,7 +50,7 @@ class Punctuation:
         if self.language_code in ['en', 'en_bio']:
             if len(os.listdir(cache + 'deployed_models/model_data/transformers_cache')) != 15:
                 wget.download(
-                    f'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/en/distilbert_base_uncased_huggingface_files.zip',
+                    f'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/en/distilbert_base_uncased_huggingface_files.zip',
                     cache + 'deployed_models/model_data/', bar=self.bar_thermometer
                 )
                 shutil.unpack_archive(cache + 'deployed_models/model_data' + '/distilbert_base_uncased_huggingface_files.zip',
@@ -58,40 +58,40 @@ class Punctuation:
                 
             if not os.path.exists(self.model_path):
                 wget.download(
-                    f'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/{self.language_code}/punctuation_en_distilbert.nemo',
+                    f'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/{self.language_code}/punctuation_en_distilbert.nemo',
                     self.model_path, bar=self.bar_thermometer)
         else:
             if len(os.listdir(self.albert_metadata)) != 4:
                 wget.download(
-                    'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/albert_metadata/config.json',
+                    'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/albert_metadata/config.json',
                     self.albert_metadata + 'config.json', bar=self.bar_thermometer
                 )
                 wget.download(
-                    'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/albert_metadata/pytorch_model.bin',
+                    'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/albert_metadata/pytorch_model.bin',
                     self.albert_metadata + 'pytorch_model.bin', bar=self.bar_thermometer
                 )
                 wget.download(
-                    'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/albert_metadata/spiece.model',
+                    'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/albert_metadata/spiece.model',
                     self.albert_metadata + 'spiece.model', bar=self.bar_thermometer
                 )
                 wget.download(
-                    'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/albert_metadata/spiece.vocab',
+                    'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/albert_metadata/spiece.vocab',
                     self.albert_metadata + 'spiece.vocab', bar=self.bar_thermometer
                 )
 
             if not os.path.exists(self.model_path):
                 wget.download(
-                    f'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/{self.language_code}/{self.language_code}.pt',
+                    f'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/{self.language_code}/{self.language_code}.pt',
                     self.model_path, bar=self.bar_thermometer
                 )
             if not os.path.exists(self.encoder_path):
                 wget.download(
-                    f'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/{self.language_code}/{self.language_code}.json',
+                    f'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/{self.language_code}/{self.language_code}.json',
                     self.encoder_path, bar=self.bar_thermometer
                 )
             if not os.path.exists(self.dict_map):
                 wget.download(
-                    f'https://storage.googleapis.com/vakyaansh-open-models/punctuation_models/{self.language_code}/{self.language_code}_dict.json',
+                    f'https://storage.googleapis.com/vakyansh-open-models/punctuation_models/{self.language_code}/{self.language_code}_dict.json',
                     self.dict_map, bar=self.bar_thermometer
                 )
 

--- a/src/punctuate/punctuate_text.py
+++ b/src/punctuate/punctuate_text.py
@@ -97,9 +97,9 @@ class Punctuation:
 
     def load_model_parameters(self):
         self.download_model_data()
-        with open(self.encoder_path) as label_encoder:
+        with open(self.encoder_path, encoding='utf-8') as label_encoder:
             train_encoder = json.load(label_encoder)
-        with open(self.dict_map) as dict_map:
+        with open(self.dict_map, encoding='utf-8') as dict_map:
             punctuation_dict = json.load(dict_map)
 
         tokenizer = AlbertTokenizer.from_pretrained(self.albert_metadata)


### PR DESCRIPTION
The url in the download models function has the bucket name as vakyaansh-open-models instead of vakyansh-open-models. Corrected it for all urls.